### PR TITLE
New Query Catalog

### DIFF
--- a/catalog.md
+++ b/catalog.md
@@ -8,7 +8,6 @@
 | Active | `True` |
 | Type | `LegacyRequest` |
 | Descriptor | `{"type":"LegacyRequest","legacy_id":1}` |
-| Manual | `False` |
 | Query ID | `0x0000000000000000000000000000000000000000000000000000000000000001` |
 | Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a317d` |
 
@@ -20,7 +19,6 @@
 | Active | `True` |
 | Type | `LegacyRequest` |
 | Descriptor | `{"type":"LegacyRequest","legacy_id":2}` |
-| Manual | `False` |
 | Query ID | `0x0000000000000000000000000000000000000000000000000000000000000002` |
 | Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a327d` |
 
@@ -32,7 +30,6 @@
 | Active | `True` |
 | Type | `LegacyRequest` |
 | Descriptor | `{"type":"LegacyRequest","legacy_id":10}` |
-| Manual | `False` |
 | Query ID | `0x000000000000000000000000000000000000000000000000000000000000000a` |
 | Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a31307d` |
 
@@ -44,7 +41,6 @@
 | Active | `True` |
 | Type | `LegacyRequest` |
 | Descriptor | `{"type":"LegacyRequest","legacy_id":41}` |
-| Manual | `True` |
 | Query ID | `0x0000000000000000000000000000000000000000000000000000000000000029` |
 | Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a34317d` |
 
@@ -56,7 +52,6 @@
 | Active | `True` |
 | Type | `LegacyRequest` |
 | Descriptor | `{"type":"LegacyRequest","legacy_id":50}` |
-| Manual | `False` |
 | Query ID | `0x0000000000000000000000000000000000000000000000000000000000000032` |
 | Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a35307d` |
 
@@ -68,6 +63,6 @@
 | Active | `True` |
 | Type | `LegacyRequest` |
 | Descriptor | `{"type":"LegacyRequest","legacy_id":59}` |
-| Manual | `False` |
 | Query ID | `0x000000000000000000000000000000000000000000000000000000000000003b` |
 | Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a35397d` |
+

--- a/catalog.md
+++ b/catalog.md
@@ -1,0 +1,73 @@
+# TellorX Query Catalog
+
+## Legacy ETH/USD spot price
+
+| Parameter | Value |
+| --- | --- |
+| Tag | `eth-usd-legacy` |
+| Active | `True` |
+| Type | `LegacyRequest` |
+| Descriptor | `{"type":"LegacyRequest","legacy_id":1}` |
+| Manual | `False` |
+| Query ID | `0x0000000000000000000000000000000000000000000000000000000000000001` |
+| Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a317d` |
+
+## Legacy BTC/USD spot price
+
+| Parameter | Value |
+| --- | --- |
+| Tag | `btc-usd-legacy` |
+| Active | `True` |
+| Type | `LegacyRequest` |
+| Descriptor | `{"type":"LegacyRequest","legacy_id":2}` |
+| Manual | `False` |
+| Query ID | `0x0000000000000000000000000000000000000000000000000000000000000002` |
+| Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a327d` |
+
+## Legacy AMPL/USD custom price
+
+| Parameter | Value |
+| --- | --- |
+| Tag | `ampl-legacy` |
+| Active | `True` |
+| Type | `LegacyRequest` |
+| Descriptor | `{"type":"LegacyRequest","legacy_id":10}` |
+| Manual | `False` |
+| Query ID | `0x000000000000000000000000000000000000000000000000000000000000000a` |
+| Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a31307d` |
+
+## Legacy USPCE value
+
+| Parameter | Value |
+| --- | --- |
+| Tag | `uspce-legacy` |
+| Active | `True` |
+| Type | `LegacyRequest` |
+| Descriptor | `{"type":"LegacyRequest","legacy_id":41}` |
+| Manual | `True` |
+| Query ID | `0x0000000000000000000000000000000000000000000000000000000000000029` |
+| Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a34317d` |
+
+## Legacy TRB/USD spot price
+
+| Parameter | Value |
+| --- | --- |
+| Tag | `trb-usd-legacy` |
+| Active | `True` |
+| Type | `LegacyRequest` |
+| Descriptor | `{"type":"LegacyRequest","legacy_id":50}` |
+| Manual | `False` |
+| Query ID | `0x0000000000000000000000000000000000000000000000000000000000000032` |
+| Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a35307d` |
+
+## Legacy ETH/JPY spot price
+
+| Parameter | Value |
+| --- | --- |
+| Tag | `eth-jpy-legacy` |
+| Active | `True` |
+| Type | `LegacyRequest` |
+| Descriptor | `{"type":"LegacyRequest","legacy_id":59}` |
+| Manual | `False` |
+| Query ID | `0x000000000000000000000000000000000000000000000000000000000000003b` |
+| Query data | `0x7b2274797065223a224c656761637952657175657374222c226c65676163795f6964223a35397d` |


### PR DESCRIPTION
The `catalog.md` readme file is intended to be maintained as a catalog of all known queries.
The file is auto-generated from Telliot, which would be updated as new queries are recognized.

Each query is given a short string called the `tag` that uniquely identifies it in the catalog. These tags will be manually added/maintained for all known queries. Alternates for the name `tag` could include `cid` (catalog ID), `sku` etc....  Might have been nice to use `qid` (queryID) but that might get confused with the hash.
The `tag` may end up becoming the main identifier used by users because it will be the shortest/most convenient.

Queries have an `active` flag.  If not active, a query should not be relied upon.

Should we consider having another flag indicating that it is supported/recognized by the team  e.g. `approved`, `certified`?

