### PR TITLE
Fix param name in JSON for Diva query

### DIFF
--- a/types/DivaProtocolPolygon.md
+++ b/types/DivaProtocolPolygon.md
@@ -30,7 +30,7 @@ The query response will consist of a single 256-bit value in the following forma
         "type": "divaProtocolPolygon",
         "inputs": [{
             "type": "uint256",
-            "name": "poolID"
+            "name": "poolId"
         }],
         "outputs": [
             {


### PR DESCRIPTION
it was `poolID` when it should be `poolId`