### PR TITLE
Update expected response for DIVA Protocol query type

### DIFF
--- a/types/DIVAProtocolPolygon.md
+++ b/types/DIVAProtocolPolygon.md
@@ -63,7 +63,7 @@ _JSON Representation:_
     }
   ],
   "response": {
-    "type": "ufixed256x18",
+    "type": "(ufixed256x18,ufixed256x18)",
     "packed": false
   }
 }

--- a/types/DIVAProtocolPolygon.md
+++ b/types/DIVAProtocolPolygon.md
@@ -35,7 +35,7 @@ The `poolId` should be a valid prediction market on the DIVAProtocol on the Poly
 
 ## Response Type
 
-The query response will consist of a two floats represented as 256-bit integer values with 18 decimals of precision. These floats are the price of the reference asset and the price of the collateral token.
+The query response will consist of a two floats represented as 256-bit integer values with 18 decimals of precision. These floats are the price of the reference asset and the price of the collateral token, in that order.
 
 - `abi_type`: (ufixed256x18,ufixed256x18)
 - `packed`: false
@@ -87,9 +87,9 @@ keccak256(abi.encode("DIVAProtocolPolygon",abi.encode(1)))
 
 ### Encoding/Decoding
 
-A value of 99.9 would be submitted on-chain using the following bytes:
+For example, if the reference asset is ETH/USD with a price of $2,819.35, and the collateral token is DAI/USD at a price of $0.9996, then the hexadecimal of the bytes-encoded expected response for this query-- ready to be submitted by a reporter --is:
 
-`0x0000000000000000000000000000000000000000000000056a6418b505860000`
+`0x00000000000000000000000000000008490b0f122862a11da8c6ac40000000000000000000000000000000000000000000c08415c61401a79c97e10c00000000`
 
 ## Dispute Considerations
 

--- a/types/DIVAProtocolPolygon.md
+++ b/types/DIVAProtocolPolygon.md
@@ -37,18 +37,15 @@ The `poolId` should be a valid prediction market on the DIVAProtocol on the Poly
 
 The query response will consist of a two floats represented as 256-bit integer values with 18 decimals of precision. These floats are the price of the reference asset and the price of the collateral token, in that order.
 
-- `abi_type`: (ufixed256x18,ufixed256x18)
+- `abi_type`: `(ufixed256x18,ufixed256x18)`
 - `packed`: false
 
 An example of encoding and decoding this response type using Python:
 
 ```python
-response = (1234.1234, 123.123)
-response_as_ints = tuple(int(v * 1e18) for v in data)
-encoded_rsp_method_1 = encode_abi(["ufixed256x18", "ufixed256x18"], response_as_ints)
-encoded_rsp_method_2 = encode_single("(ufixed256x18,ufixed256x18)", response_as_ints)
-
-assert encoded_rsp_method_1 == encoded_rsp_method_2
+data = [2819.35, 0.9996]
+submit_value = encode_abi(["uint256", "uint256"], [int(v * 1e18) for v in data])
+print(submit_value)
 ```
 
 _JSON Representation:_
@@ -89,7 +86,7 @@ keccak256(abi.encode("DIVAProtocolPolygon",abi.encode(1)))
 
 For example, if the reference asset is ETH/USD with a price of $2,819.35, and the collateral token is DAI/USD at a price of $0.9996, then the hexadecimal of the bytes-encoded expected response for this query-- ready to be submitted by a reporter --is:
 
-`0x00000000000000000000000000000008490b0f122862a11da8c6ac40000000000000000000000000000000000000000000c08415c61401a79c97e10c00000000`
+`0x000000000000000000000000000000000000000000000098d6574f71899000000000000000000000000000000000000000000000000000000ddf4ae7657b0000`
 
 ## Dispute Considerations
 

--- a/types/DIVAProtocolPolygon.md
+++ b/types/DIVAProtocolPolygon.md
@@ -20,43 +20,56 @@ To get the pool information, run
 
 The first result is the reference asset which should be returned for the value on expiry time (9th parameter)
 
-e.g  -  referenceAsset: 'ETH/USDT',
+e.g - referenceAsset: 'ETH/USDT',
 e.g. - expiryDate: BigNumber { value: "1642021490" },
 
 In this example, if poolId 1 refers to these data, you would return the ETH/USDT price at 1642021490
 
 ## Query Parameters
 
-The `DIVAProtocolPolygon` query has one parameter, which specifies the requested data.  
+The `DIVAProtocolPolygon` query has one parameter, which specifies the requested data.
 
-1. **poolId** (uint256): ID of the prediction market. 
+1. **poolId** (uint256): ID of the prediction market.
 
 The `poolId` should be a valid prediction market on the DIVAProtocol on the Polygon network, ready to be settled. The parameter name `poolId` is the same name used within the DIVA protocol contracts for a prediction market identifier.
 
 ## Response Type
 
-The query response will consist of a single 256-bit value in the following format:
+The query response will consist of a two floats represented as 256-bit integer values with 18 decimals of precision. These floats are the price of the reference asset and the price of the collateral token.
 
-- `abi_type`: ufixed256x18 (18 decimals of precision)
+- `abi_type`: (ufixed256x18,ufixed256x18)
 - `packed`: false
 
-*JSON Representation:*
+An example of encoding and decoding this response type using Python:
 
-```json
-    {
-        "type": "DIVAProtocolPolygon",
-        "abi": [{
-            "type": "uint256",
-            "name": "poolId",
-        }],
-        "response": {
-            "type": "ufixed256x18",
-            "packed":false,
-        }
-    }
+```python
+response = (1234.1234, 123.123)
+response_as_ints = tuple(int(v * 1e18) for v in data)
+encoded_rsp_method_1 = encode_abi(["ufixed256x18", "ufixed256x18"], response_as_ints)
+encoded_rsp_method_2 = encode_single("(ufixed256x18,ufixed256x18)", response_as_ints)
+
+assert encoded_rsp_method_1 == encoded_rsp_method_2
 ```
 
-*queryData:*
+_JSON Representation:_
+
+```json
+{
+  "type": "DIVAProtocolPolygon",
+  "abi": [
+    {
+      "type": "uint256",
+      "name": "poolId"
+    }
+  ],
+  "response": {
+    "type": "ufixed256x18",
+    "packed": false
+  }
+}
+```
+
+_queryData:_
 
 ```s
 abi.encode("DIVAProtocolPolygon", abi.encode(1))
@@ -64,7 +77,8 @@ abi.encode("DIVAProtocolPolygon", abi.encode(1))
 
 `0x0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000136469766150726f746f636f6c506f6c79676f6e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001`
 
-*queryID:*
+_queryID:_
+
 ```s
 keccak256(abi.encode("DIVAProtocolPolygon",abi.encode(1)))
 ```
@@ -77,15 +91,14 @@ A value of 99.9 would be submitted on-chain using the following bytes:
 
 `0x0000000000000000000000000000000000000000000000056a6418b505860000`
 
-
 ## Dispute Considerations
 
 Reporters should use care in selecting data sources and choosing the algorithm to combine them.
 
-- The prediction market nature of DIVA Protocol means that the query could have a result that is a price, a temperature, a boolean, a sports score, or any different format for the data.  
-- The result should be the correct one AT THE TIME of expiration. This means that if the prediction market bets on the price of BTC/USD on Feb 1st at midnight, the query should always return the price of BTC/USD at midnight on Feb 1st, even if it get called/requested again. 
+- The prediction market nature of DIVA Protocol means that the query could have a result that is a price, a temperature, a boolean, a sports score, or any different format for the data.
+- The result should be the correct one AT THE TIME of expiration. This means that if the prediction market bets on the price of BTC/USD on Feb 1st at midnight, the query should always return the price of BTC/USD at midnight on Feb 1st, even if it get called/requested again.
 - Multiple sources should be used whenever possible.
 - When retrieving data directly from exchanges, feed users might expect that exchanges with lower volumes have their prices weighted accordingly to avoid erratic results.
-- Care should also be used when retrieving data from aggregators.  
-- It is the reporters responsibility to ensure that the feed result is *reasonable* enough for a community consensus, otherwise it may be subject to dispute.
-- If a *reasonable* value cannot be determined, a value should not be submitted
+- Care should also be used when retrieving data from aggregators.
+- It is the reporters responsibility to ensure that the feed result is _reasonable_ enough for a community consensus, otherwise it may be subject to dispute.
+- If a _reasonable_ value cannot be determined, a value should not be submitted


### PR DESCRIPTION
Switching from expecting a float with 18 decimals of precision to two of the same (reference asset price, collateral token price): `(ufixed256x18,ufixed256x18)`