### PR TITLE
Update and rename GasPriceOracle.md to HistoricalGasPrice.md

### DIFF
--- a/types/HistoricalGasPrice.md
+++ b/types/HistoricalGasPrice.md
@@ -5,8 +5,9 @@
 
 
 ## Description
+This is a query type for the Tellor network, named HistoricalGasPrice, which is engineered to estimate the historical gas price in gwei. This is particularly beneficial for protocols that aim to refund users for their expended gas.
 
-This is a query type for reporting a gas price in gwei to the Tellor network. The query type will be called `HistoricalGasPrice. An Example use case is for gas refunds: protocols will need an accurate estimate for the cost of historical user transactions in gas. Given its approach, this `HistoricalGasPrice` is best suited for refunding users an approximation of their gas spent according to an average of gas prices from that time period.
+The HistoricalGasPrice query type operates by examining the average gas prices at a given timestamp. It achieves this by reporting the median gas price from the block that corresponds to the given timestamp. Since finding a block that perfectly matches the given timestamp isn't always feasible, the block that is closest to, but not later than, the given timestamp is used. This ensures that the user reimbursement is based on a representative gas price, even when an exact match for the timestamp isn't available.
 
 
 ## Query Parameters

--- a/types/HistoricalGasPrice.md
+++ b/types/HistoricalGasPrice.md
@@ -1,17 +1,17 @@
 
 ## Type Name
 
-`GasPriceOracle`
+`HistoricalGasPrice`
 
 
 ## Description
 
-This is a proposal for a new query type for reporting a gas price in gwei to the Tellor network. The query type will be called `GasPriceOracle`. Its main use case is for gas refunds: protocols will need an accurate estimate for the cost of historical user transactions in gas. Given its approach, this `GasPriceOracle` is best suited for refunding users an approximation of their gas spent according to an average of gas prices from that time period.
+This is a query type for reporting a gas price in gwei to the Tellor network. The query type will be called `HistoricalGasPrice. An Example use case is for gas refunds: protocols will need an accurate estimate for the cost of historical user transactions in gas. Given its approach, this `HistoricalGasPrice` is best suited for refunding users an approximation of their gas spent according to an average of gas prices from that time period.
 
 
 ## Query Parameters
 
-The parameters of the `GasPriceOracle` query type will be the `chainId` and `timestamp`
+The parameters of the `HistoricalGasPrice` query type will be the `chainId` and `timestamp`
 
 ```
 1. chainId
@@ -25,7 +25,7 @@ The parameters of the `GasPriceOracle` query type will be the `chainId` and `tim
 
 ## Response Type
 
-`GasPriceOracle`'s response type is an unpacked 256 bit value with 18 decimals of precision. It's response type is measured in gwei:
+`HistoricalGasPrice`'s response type is an unpacked 256 bit value with 18 decimals of precision. It's response type is measured in gwei:
 ```
 - abi_type: ufixed256x18 (18 decimals of precision)
 - packed: false
@@ -35,7 +35,7 @@ The parameters of the `GasPriceOracle` query type will be the `chainId` and `tim
 ## Query Data
 
 ```s
-queryData = abi.encode("GasPriceOracle", abi.encode(1, 1650465649))
+queryData = abi.encode("HistoricalGasPrice", abi.encode(1, 1650465649))
 ```
 
 ## Query ID
@@ -52,10 +52,10 @@ You can use [this tool](https://queryidbuilder.herokuapp.com/custom) to generate
 
 
 ## JSON Representation
-The JSON representation of a `GasPriceOracle` query:
+The JSON representation of a `HistoricalGasPrice` query:
 ```json
 {
-    "type": "GasPriceOracle",
+    "type": "HistoricalGasPrice",
     "abi": [
         {
             "type": "uint256",
@@ -80,14 +80,14 @@ A working example mapping of all the various inputs and parameters to a valid qu
 The queryData for mainnet ethereum (chainId `1`) at unix timestamp `1650465649`:
 
 ```s
-queryData = abi.encode("GasPriceOracle", abi.encode(1, 1650465649))
+queryData = abi.encode("HistoricalGasPrice", abi.encode(1, 1650465649))
 queryId = keccack256(queryData)
 ```
 
-queryData: `0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000e47617350726963654f7261636c65000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000062601b71`
+queryData: `0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000012486973746f726963616c47617350726963650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000062601b71`
 
 queryId:
-`0x7dd07b75e8c096ea1926e9a2cc8f749b04581d0ae88a892989f05790384344f6`
+`0xf451dd40a7d42f120c488d1b27d148b3deb1293d22bd7378e524e12d0a659584`
 
 You can use [this tool](https://queryidbuilder.herokuapp.com/custom) to generate query IDs.
 


### PR DESCRIPTION
Proposing we do this name change in order to avoid confusion on intended use cases.

Not 100% certain I have the example's querydata and queryid correct.